### PR TITLE
Adding support for making UI templates into components

### DIFF
--- a/froactful.lua
+++ b/froactful.lua
@@ -27,7 +27,7 @@ type Element = any
 -- type Children = Element | { Element } | nil
 type Children = any? -- For simpler definitions, since it's the equivalent as above
 
-local function newE(roact, hooks, defaults: { DefaultPropertyConfig })
+local function newE(roact: any, hooks, defaults: { DefaultPropertyConfig })
 	return function(class: string, props: { [string]: any }, children: Children)
 		for _, default in defaults do
 			if isA(class, default.class) and not props[default.property] then
@@ -38,12 +38,64 @@ local function newE(roact, hooks, defaults: { DefaultPropertyConfig })
 	end
 end
 
+local function newTemplate(roact: any, unpureByDefault: boolean?)
+	type CleanupMethod = () -> ()
+	type UpdateMethod<Props> = (props: Props) -> ()
+	type Constructor<Props> = (
+		name: string,
+		parent: Instance,
+		onUpdate: (UpdateMethod<Props>) -> ()
+	) -> CleanupMethod
+	return function<Props>(config: ComponentConfig, f: Constructor<Props>)
+		local isPure = if config.pure == nil
+			then not unpureByDefault
+			else config.pure
+		local Component = if isPure
+			then roact.PureComponent:extend(config.name or "Component")
+			else roact.Component:extend(config.name or "Component")
+		function Component:init()
+			local _className, hostKey, hostParent, _children
+			for name, field in self do
+				if tostring(name) == "Symbol(InternalData)" then
+					_className = field.componentClass
+					hostKey = field.virtualNode.hostKey
+					hostParent = field.virtualNode.hostParent
+					_children = field.virtualNode.children
+				end
+			end
+			self.updateCallbacks = {}
+			self.cleanup = f(hostKey, hostParent, function(f)
+				table.insert(self.updateCallbacks, f)
+			end)
+		end
+		function Component:render()
+			return roact.createFragment()
+		end
+		function Component:didMount()
+			for _, callback in self.updateCallbacks do
+				callback(self.props)
+			end
+		end
+		function Component:didUpdate()
+			for _, callback in self.updateCallbacks do
+				callback(self.props)
+			end
+		end
+		function Component:willUnmount()
+			self.cleanup()
+		end
+		return function(props: Props, children)
+			return roact.createElement(Component, props, children)
+		end
+	end
+end
+
 -- stylua: ignore
 type ListConfig = (
 	{ orderByName: boolean?, setOrder: true, initial: number?, key: string? }
 	| { orderByName: boolean?, setOrder: false?, initial: nil, key: string? }
 )
-local function newList(roact)
+local function newList(roact: any)
 	return function(config: ListConfig, elements: { [number]: Element })
 		local index = if config.initial then config.initial else 0
 		local count: { [string]: number } = {}
@@ -101,7 +153,7 @@ type HookFunction<Props, Hooks> = (
 ) -> any
 
 local function newC<Hooks>(
-	roact,
+	roact: any,
 	hooks: HookFunction<any, Hooks>,
 	unpureByDefault: boolean?
 )
@@ -109,15 +161,11 @@ local function newC<Hooks>(
 		config: ComponentConfig,
 		body: (Props, Hooks) -> any
 	): (Props, Children) -> any
-		if not unpureByDefault then
-			if config.pure == nil then
-				config.pure = true
-			end
-		end
+		local isPure = if config.pure == nil
+			then not unpureByDefault
+			else config.pure
 		local Component = hooks(body, {
-			componentType = if config.pure
-				then "PureComponent"
-				else "Component",
+			componentType = if isPure then "PureComponent" else "Component",
 			name = if config.name then config.name else "Component",
 		})
 		return function(props, children)
@@ -381,6 +429,7 @@ function froact.configure<Hooks>(config: {
 		e = e,
 		c = newC(config.Roact, config.Hooks, config.unpureByDefault),
 		list = newList(config.Roact),
+		template = newTemplate(config.Roact, config.unpureByDefault),
 		Camera = Camera,
 		CanvasGroup = CanvasGroup,
 		Frame = Frame,


### PR DESCRIPTION
This adds support for turning template-based UI into components. This is useful when gradually porting an existing codebase to Roact, or for having legacy UI still work without having to recode it.
Templates do not support hooks by default, so if you want to add functionality you should wrap the template in another froact component.
```lua
local HealthBarTemplate = froact.template({ name = "HealthBar" }, function(name, parent, onUpdate)
    local rbx = ReplicatedStorage.UI.HealthBar:Clone()
    rbx.Name = name
    rbx.Parent = parent
    onUpdate(function(props: { percent: number })
        rbx.Percent.Size = UDim2.fromScale(props.percent, 0)
    end)
    return function()
        rbx:Destroy()
    end
})
```