### PR TITLE
Pass child elements in as a third argument to component's body

### DIFF
--- a/froact.lua
+++ b/froact.lua
@@ -146,8 +146,10 @@ local function newList(roact: any)
 	end
 end
 
+local blankChildren = table.freeze({})
+
 type HookFunction<Props, Hooks> = (
-	render: (Props, Hooks) -> any,
+	render: (Props, Hooks, { Element }) -> any,
 	options: any
 ) -> any
 
@@ -158,12 +160,18 @@ local function newC<Hooks>(
 )
 	return function<Props>(
 		config: ComponentConfig,
-		body: (Props, Hooks) -> any
+		body: (Props, Hooks, { Element }) -> any
 	): (Props, Children) -> any
 		local isPure = if config.pure == nil
 			then not unpureByDefault
 			else config.pure
-		local Component = hooks(body, {
+		-- Wrap the body to have children passed in as a third argument
+		local function wrappedBody(props: any, hooks)
+			local children = props[roact.Children]
+			props[roact.Children] = nil
+			body(props, hooks, if children then children else blankChildren)
+		end
+		local Component = hooks(wrappedBody, {
 			componentType = if isPure then "PureComponent" else "Component",
 			name = if config.name then config.name else "Component",
 		})


### PR DESCRIPTION
Allows you to write the following code
```lua
local Button = froact.c({}, function(props, hooks, children)
    return froact.ImageButton({
        BackgroundColor3 = props.color
     }, children)
end)
local element = Button({}, {
    UIScale = froact.UIScale({ Scale = 2 })
})
```
rather than having to get children via `props[froact.Roact.Children]`
This also removes that key from props, so you must use children via the third argument from now on.